### PR TITLE
set up build and push pipeline to Docker Hub

### DIFF
--- a/.github/workflow/build-image.yaml
+++ b/.github/workflow/build-image.yaml
@@ -1,27 +1,30 @@
 name: Build image and push to Docker Hub
 
 on:
-  push:
-    branches:
-      - 'main'
+    push:
+        branches:
+            - "main"
+    pull_request:
+        branches:
+            - "main"
 
 jobs:
-  docker:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v2
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v2
-      - name: Login to Docker Hub
-        uses: docker/login-action@v2
-        with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
-      - name: Build and push
-        uses: docker/build-push-action@v3
-        with:
-          file: docker/Dockerfile
-          platforms: linux/amd64,linux/arm64v8
-          push: true
-          tags: giantmolecularcloud/mi300-influx:latest
+    docker:
+        runs-on: ubuntu-latest
+        steps:
+            - name: Set up QEMU
+              uses: docker/setup-qemu-action@v2
+            - name: Set up Docker Buildx
+              uses: docker/setup-buildx-action@v2
+            - name: Login to Docker Hub
+              uses: docker/login-action@v2
+              with:
+                  username: ${{ secrets.DOCKERHUB_USERNAME }}
+                  password: ${{ secrets.DOCKERHUB_TOKEN }}
+            - name: Build and push
+              uses: docker/build-push-action@v3
+              with:
+                  file: docker/Dockerfile
+                  platforms: linux/amd64,linux/arm64v8
+                  push: true
+                  tags: giantmolecularcloud/mi300-influx:latest


### PR DESCRIPTION
Use an action to build images and push them to Docker Hub on pushes or PRs on 'main'.